### PR TITLE
Update static figures when compiling

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -2,8 +2,8 @@
 # Copy over the static figures
 rule static_figures:
     input:
-        "src/static/optimistic_statpwr_H2O-f.pdf"
+        "src/static/*.pdf"
     output:
-        "src/tex/figures/optimistic_statpwr_H2O-f.pdf"
+        "src/tex/figures/*.pdf"
     shell:
         "cp {input} {output}"


### PR DESCRIPTION
Includes a snakemake rule to ensure updated figures in `src/static/` are processed before a new PDF is generated.